### PR TITLE
Add plugin meta

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "description": "A tool to allow easy prototyping with The Pension Regulator's design system."
+  },
   "pluginDependencies": ["govuk-frontend"],
   "assets": [
     "/assets"

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "description": "A tool to allow easy prototyping with The Pension Regulator's design system."
+    "description": "A tool to allow easy prototyping with The Pensions Regulator's design system."
   },
   "pluginDependencies": ["govuk-frontend"],
   "assets": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "tpr-prototype-frontend",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tpr-prototype-frontend",
+      "version": "0.0.1",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
I've added a description to the plugin config, this will show up when the plugin is installed into a prototype kit on the new pages we're in the process of building.